### PR TITLE
Update to 1.0.49 (it's a newer build than the one currently set on master/f25/f24)

### DIFF
--- a/lpf-spotify-client.spec
+++ b/lpf-spotify-client.spec
@@ -12,7 +12,7 @@
 Name:           lpf-spotify-client
                 # Upstream spotify version, verbatim.
 Version:        1.0.49
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Spotify music player native client package bootstrap
 
 License:        MIT
@@ -76,6 +76,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 
 %changelog
+* Sun Mar 13 2017 Pedro Albuquerque Santos <petersaints@gmail.com.com> - 1.0.49-2
+- Update to spotify-client_1.0.49.125.g72ee7853-111_amd64.deb and spotify-client_1.0.49.125.g72ee7853-22_i386.deb
+
 * Sun Feb 12 2017 Sérgio Basto <sergio@serjux.com> - 1.0.49-1
 - Update to 1.0.49
 

--- a/spotify-client.spec.in
+++ b/spotify-client.spec.in
@@ -12,7 +12,7 @@
 
 Name:           spotify-client
 Version:        1.0.49
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Spotify music player native client
 
 # board=http://community.spotify.com/t5/Desktop-Linux
@@ -116,6 +116,9 @@ fi
 
 
 %changelog
+* Sun Mar 13 2017 Pedro Albuquerque Santos <petersaints@gmail.com.com> - 1.0.49-2
+- Update to spotify-client_1.0.49.125.g72ee7853-111_amd64.deb and spotify-client_1.0.49.125.g72ee7853-22_i386.deb
+
 * Sun Feb 12 2017 Sérgio Basto <sergio@serjux.com> - 1.0.49-1
 - Update to 1.0.49
 

--- a/spotify-client.spec.in
+++ b/spotify-client.spec.in
@@ -23,8 +23,8 @@ Group:          Applications/Multimedia
 ExclusiveArch:  i386 i686 x86_64
 
 Source0:        spotify-make-%{shortcommit}.tar.gz
-Source1:        %{repo}/spotify-client_%{version}.125.g72ee7853-83_amd64.deb
-Source2:        %{repo}/spotify-client_%{version}.125.g72ee7853-21_i386.deb
+Source1:        %{repo}/spotify-client_%{version}.125.g72ee7853-111_amd64.deb
+Source2:        %{repo}/spotify-client_%{version}.125.g72ee7853-22_i386.deb
 
 %ifarch x86_64
 %global   spotify_pkg   %{SOURCE1}


### PR DESCRIPTION
I updated the package so that it gets the 1.0.47 version from Spotify's Debian repository.

More details at: https://bugzilla.rpmfusion.org/show_bug.cgi?id=4371#c9

