### PR TITLE
Update to 1.0.64.407.g9bd02c2d

### DIFF
--- a/lpf-spotify-client.spec
+++ b/lpf-spotify-client.spec
@@ -11,8 +11,8 @@
 
 Name:           lpf-spotify-client
                 # Upstream spotify version, verbatim.
-Version:        1.0.59.395
-Release:        2%{?dist}
+Version:        1.0.64.407
+Release:        1%{?dist}
 Summary:        Spotify music player native client package bootstrap
 
 License:        MIT
@@ -79,6 +79,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 
 %changelog
+* Fri Oct 06 2017 Vesa Kaihlavirta <vegai@iki.fi> - 1.0.64.407-1
+- Update to 1.0.64.407.g9bd02c2d
+
 * Thu Aug 31 2017 RPM Fusion Release Engineering <kwizart@rpmfusion.org> - 1.0.59.395-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
 

--- a/spotify-client.spec.in
+++ b/spotify-client.spec.in
@@ -11,8 +11,8 @@
 
 
 Name:           spotify-client
-Version:        1.0.59.395
-Release:        2%{?dist}
+Version:        1.0.64.407
+Release:        1%{?dist}
 Summary:        Spotify music player native client
 
 # board=http://community.spotify.com/t5/Desktop-Linux
@@ -25,11 +25,11 @@ ExclusiveArch:  i386 i686 x86_64
 Source0:        spotify-make-%{shortcommit}.tar.gz
 
 %ifarch x86_64
-Source1:        %{repo}/spotify-client_%{version}.ge6ca9946-18_amd64.deb
+Source1:        %{repo}/spotify-client_%{version}.g9bd02c2d-26_amd64.deb
 %global   spotify_pkg   %{SOURCE1}
 %global   req_64        ()(64bit)
 %else
-Source2:        %{repo}/spotify-client_%{version}.ge6ca9946-18_i386.deb
+Source2:        %{repo}/spotify-client_%{version}.g9bd02c2d-26_i386.deb
 %global   spotify_pkg   %{SOURCE2}
 %endif
 
@@ -116,6 +116,9 @@ fi
 
 
 %changelog
+* Fri Oct 06 2017 Vesa Kaihlavirta <vegai@iki.fi> - 1.0.64.407-1
+- Update to 1.0.64.407.g9bd02c2d
+
 * Thu Aug 31 2017 RPM Fusion Release Engineering <kwizart@rpmfusion.org> - 1.0.59.395-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
 


### PR DESCRIPTION
Current package not building because upstream removed the earlier version.

Ran the upgrading python script, checked the results and voila.
