### PR TITLE
Update to 1.2.31.1205.g4d59ad7c

### DIFF
--- a/lpf-spotify-client.spec
+++ b/lpf-spotify-client.spec
@@ -11,7 +11,7 @@
 
 Name:           lpf-spotify-client
                 # Upstream spotify version, verbatim.
-Version:        1.2.26.1187
+Version:        1.2.31.1205
 Release:        1%{?dist}
 Summary:        Spotify music player native client package bootstrap
 
@@ -79,6 +79,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 
 %changelog
+* Wed May 01 2024 Valentin Maerten <maerten.valentin@gmail.com> - 1.2.31.1205-1
+- Update to 1.2.31.1205.g4d59ad7c
+
 * Mon Dec 18 2023 Sérgio Basto <sergio@serjux.com> - 1.2.26.1187-1
 - Update to 1.2.26.1187.g36b715a1
 

--- a/spotify-client.spec.in
+++ b/spotify-client.spec.in
@@ -13,7 +13,7 @@
 
 
 Name:           spotify-client
-Version:        1.2.26.1187
+Version:        1.2.31.1205
 Release:        1%{?dist}
 Summary:        Spotify music player native client
 
@@ -27,7 +27,7 @@ ExclusiveArch:  %{ix86} x86_64
 Source0:        spotify-make-%{shortcommit}.tar.gz
 
 %ifarch x86_64
-Source1:        %{repo}/spotify-client_%{version}.g36b715a1_amd64.deb
+Source1:        %{repo}/spotify-client_%{version}.g4d59ad7c_amd64.deb
 %global   spotify_pkg   %{SOURCE1}
 %global   req_64        ()(64bit)
 %else
@@ -110,6 +110,9 @@ ln -s ../libcurl.so.4 libcurl-gnutls.so.4
 
 
 %changelog
+* Wed May 01 2024 Valentin Maerten <maerten.valentin@gmail.com> - 1.2.31.1205-1
+- Update to 1.2.31.1205.g4d59ad7c
+
 * Mon Dec 18 2023 Sérgio Basto <sergio@serjux.com> - 1.2.26.1187-1
 - Update to 1.2.26.1187.g36b715a1
 


### PR DESCRIPTION
I've used your script `check_new_version.py` to do it, but I haven't the right to checkout, push and build.

As issue are not enable, I take this PR as a opportunity to ask you, can be worth it to add a github action that check if a new version is available ? (for example every day or week)
The issue is : they delete the old .deb so we cannot update if the last version is not available on this repo.
If yes, I can propose a PR to do it.

Thanks for maintaining this 